### PR TITLE
Adds `max_default_recursion` param to `dumps()` which allows the user…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orjson"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["ijl <ijl@mailbox.org>"]
 description = "Fast, correct Python JSON library supporting dataclasses and datetimes"
 edition = "2018"

--- a/orjson.pyi
+++ b/orjson.pyi
@@ -6,6 +6,7 @@ def dumps(
     __obj: Any,
     default: Optional[Callable[[Any], Any]] = ...,
     option: Optional[int] = ...,
+    max_default_recursion: int = 5,
 ) -> bytes: ...
 def loads(__obj: Union[bytes, bytearray, str]) -> Any: ...
 

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -182,3 +182,21 @@ class TypeTests(unittest.TestCase):
 
         with self.assertRaises(orjson.JSONEncodeError):
             orjson.dumps(ref, default=default)
+
+    def test_default_recursion_user_defined(self):
+        """
+        dumps() with default function and user defined recursion limit
+        """
+        self.assertEqual(
+            orjson.dumps(Recursive(10), default=default, max_default_recursion=10),
+            b"0",
+        )
+
+    def test_default_recursion_over_user_defined(self):
+        """
+        dumps() with default function and user defined recursion limit still
+        raises JSONEncodeError
+        """
+
+        with self.assertRaises(orjson.JSONEncodeError):
+            orjson.dumps(Recursive(11), default=default, max_default_recursion=10)


### PR DESCRIPTION
… to define the recursion limit for `default()` function.